### PR TITLE
Serverless version bump v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@libsql/client": "^0.15.15",
     "@tsconfig/node24": "^24.0.1",
     "@tursodatabase/database": "^0.2.2",
-    "@tursodatabase/serverless": "^0.1.3",
+    "@tursodatabase/serverless": "^1.0.0",
     "@types/node": "^24.7.1",
     "kysely": "^0.28.8",
     "libsql": "^0.5.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@tursodatabase/serverless':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/node':
         specifier: ^24.7.1
         version: 24.7.1
@@ -90,24 +90,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.5':
     resolution: {integrity: sha512-5DjiiDfHqGgR2MS9D+AZ8kOfrzTGqLKywn8hoXpXXlJXIECGQ32t+gt/uiS2XyGBM2XQhR6ztUvbjZWeccFMoQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.5':
     resolution: {integrity: sha512-AVqLCDb/6K7aPNIcxHaTQj01sl1m989CJIQFQEaiQkGr2EQwyOpaATJ473h+nXDUuAcREhccfRpe/tu+0wu0eQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.5':
     resolution: {integrity: sha512-fq9meKm1AEXeAWan3uCg6XSP5ObA6F/Ovm89TwaMiy1DNIwdgxPkNwxlXJX8iM6oRbFysYeGnT0OG8diCWb9ew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.5':
     resolution: {integrity: sha512-xaOIad4wBambwJa6mdp1FigYSIF9i7PCqRbvBqtIi9y29QtPVQ13sDGtUnsRoe6SjL10auMzQ6YAe+B3RpZXVg==}
@@ -406,56 +410,67 @@ packages:
     resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.0':
     resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.0':
     resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.0':
     resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
     resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.0':
     resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.0':
     resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.0':
     resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.0':
     resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.0':
     resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.0':
     resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.0':
     resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
@@ -496,11 +511,13 @@ packages:
     resolution: {integrity: sha512-u3VFXFzTZd+5RxxyQVClxMHVfj6aRxV0AbdoTLJ4flUao5YMebL4p5w30vozl8wNzlSq7g4ocmCiG71btofDGg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tursodatabase/database-linux-x64-gnu@0.2.2':
     resolution: {integrity: sha512-tAu9ZQBP3sZjaeQEOyEAQoHz/oqONBQwrtE/lYZQhqpR8nZ0DrKsYUIiu4lBOcWcofwtJmOgTVM8WYayJOm4HA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tursodatabase/database-win32-x64-msvc@0.2.2':
     resolution: {integrity: sha512-C1Z1xOUSln1/qtzR60xZYHgmfrQIhNm0glgqsnZt2wQI354dDtQGZH/oG/tKWCHrvtFvWCbnd9DEZif/VCK56A==}
@@ -510,8 +527,8 @@ packages:
   '@tursodatabase/database@0.2.2':
     resolution: {integrity: sha512-BlvoyiwIWIIQA65KEYlCqLDpRKIOM1AN99tBMjz1B+ydO9h0cDb+lCbfBf6f7+Lk696KB1ODpePiF5EfGm9qpw==}
 
-  '@tursodatabase/serverless@0.1.3':
-    resolution: {integrity: sha512-S30LgeIgUo2voGLI6F5sNjCZRBd/oUtneZi9zOry1jPZqeZVLJBHWXWyKkuW2/hLnbLT1AVIrenZ4yQav2+nZg==}
+  '@tursodatabase/serverless@1.0.0':
+    resolution: {integrity: sha512-zZwsSIsdAaQ99RtyAl87j8laWe/l0uNoJIpDtXToBFty/48KaA2W/GZRq6zyrAUh8innwy758TEoFVbCWFHgkw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2076,7 +2093,7 @@ snapshots:
       '@tursodatabase/database-linux-x64-gnu': 0.2.2
       '@tursodatabase/database-win32-x64-msvc': 0.2.2
 
-  '@tursodatabase/serverless@0.1.3': {}
+  '@tursodatabase/serverless@1.0.0': {}
 
   '@types/chai@5.2.2':
     dependencies:

--- a/src/serverless/dialect-config.mts
+++ b/src/serverless/dialect-config.mts
@@ -1,20 +1,20 @@
 export interface TursoServerlessDialectConfig {
 	connection:
 		| TursoServerlessConnection
-		| (() => TursoServerlessConnection | Promise<TursoServerlessConnection>);
+		| (() => TursoServerlessConnection | Promise<TursoServerlessConnection>)
 }
 
 // See https://github.com/tursodatabase/turso/blob/main/serverless/javascript/src/connection.ts#L131
 export interface TursoServerlessConnection {
-	close: () => Promise<void>;
+	close: () => Promise<void>
 	execute: (
 		sql: string,
-		args?: unknown[]
+		args?: unknown[],
 	) => Promise<{
-		columns: string[];
-		columnTypes: string[];
-		lastInsertRowid: number | undefined;
-		rows: unknown[][];
-		rowsAffected: number;
-	}>;
+		columns: string[]
+		columnTypes: string[]
+		lastInsertRowid: number | undefined
+		rows: unknown[][]
+		rowsAffected: number
+	}>
 }

--- a/src/serverless/dialect-config.mts
+++ b/src/serverless/dialect-config.mts
@@ -1,40 +1,20 @@
 export interface TursoServerlessDialectConfig {
 	connection:
 		| TursoServerlessConnection
-		| (() => TursoServerlessConnection | Promise<TursoServerlessConnection>)
+		| (() => TursoServerlessConnection | Promise<TursoServerlessConnection>);
 }
 
+// See https://github.com/tursodatabase/turso/blob/main/serverless/javascript/src/connection.ts#L131
 export interface TursoServerlessConnection {
-	close: () => Promise<void>
-	// prepare: (sql: string) => TursoServerlessStatement
-}
-
-export interface TursoServerlessConnectionWithSession
-	extends TursoServerlessConnection {
-	session: TursoServerlessSession
-}
-
-// interface TursoServerlessStatement {
-// 	// biome-ignore lint/suspicious/noExplicitAny: this is fine.
-// 	all: (args?: any[]) => Promise<any[]>
-// 	// biome-ignore lint/suspicious/noExplicitAny: this is fine.
-// 	iterate: (args?: any[]) => AsyncGenerator<any>
-// 	// biome-ignore lint/suspicious/noExplicitAny: this is fine.
-// 	run: (args?: any[]) => Promise<{
-// 		changes: number
-// 		lastInsertRowid: bigint | undefined
-// 	}>
-// }
-
-interface TursoServerlessSession {
+	close: () => Promise<void>;
 	execute: (
 		sql: string,
-		args?: unknown[],
+		args?: unknown[]
 	) => Promise<{
-		columns: string[]
-		columnTypes: string[]
-		lastInsertRowid: number | undefined
-		rows: unknown[][]
-		rowsAffected: number
-	}>
+		columns: string[];
+		columnTypes: string[];
+		lastInsertRowid: number | undefined;
+		rows: unknown[][];
+		rowsAffected: number;
+	}>;
 }

--- a/src/serverless/driver.mts
+++ b/src/serverless/driver.mts
@@ -8,7 +8,6 @@ import type {
 import { isValidIdentifier } from '../utils.mjs'
 import type {
 	TursoServerlessConnection,
-	TursoServerlessConnectionWithSession,
 	TursoServerlessDialectConfig,
 } from './dialect-config.mjs'
 
@@ -72,15 +71,8 @@ class TursoServerlessDatabaseConnection implements DatabaseConnection {
 
 	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
 		const { parameters, sql } = compiledQuery
-
-		// we're hacking. session is unofficially exposed on connection.
-		// we're doing so because `prepare -> all/run` return an opinionated result. ({rows: Record<string, unknown>[]} / {changes: number; lastInsertRowid: bigint | undefined})
-		// such results require us to have logic that decides (gambles) which method to run.
-		// in future releases, it seems `connection` will expose `execute` directly.
-		// https://github.com/tursodatabase/turso/blob/b7c43cf293a4b627862a275333f6911c00289979/packages/turso-serverless/src/connection.ts#L77-L95
-		const result = await (
-			this.#connection as TursoServerlessConnectionWithSession
-		).session.execute(sql, [...parameters])
+		
+		const result = await (this.#connection).execute(sql, [...parameters])
 
 		const { columns, lastInsertRowid, rows: valueTuples, rowsAffected } = result
 


### PR DESCRIPTION
`@tursodatabase/serverless` has released v1.0.0. This PR updates the `@tursodatabase/serverless` package and removes workarounds required in previous minor versions.

I have not found `@tursodatabase/serverless` changelogs listing any breaking changes on the v1 release, but cannot guarantee.